### PR TITLE
Add GetSpriteFlippedHorizontally/Vertically commands.

### DIFF
--- a/common/Source/Wrapper.cpp
+++ b/common/Source/Wrapper.cpp
@@ -8390,13 +8390,13 @@ int agk::GetSpriteTransparency( UINT iSpriteIndex )
 	return pSprite->GetTransparencyMode();
 }
 
-//****f* Sprite/Properties/GetSpriteFlippedHorizontally
+//****f* Sprite/Properties/GetSpriteFlippedH
 // FUNCTION
 //   Returns 1 if the sprite has been flipped horizontally with SetSpriteFlip, otherwise returns 0.
 // INPUTS
 //   iSpriteIndex -- The ID of the sprite to check.
 // SOURCE
-int agk::GetSpriteFlippedHorizontally( UINT iSpriteIndex )
+int agk::GetSpriteFlippedH( UINT iSpriteIndex )
 //****
 {
 	cSprite *pSprite = (cSprite*)m_cSpriteList.GetItem( iSpriteIndex );
@@ -8412,13 +8412,13 @@ int agk::GetSpriteFlippedHorizontally( UINT iSpriteIndex )
 	return pSprite->GetFlippedHorizontally();
 }
 
-//****f* Sprite/Properties/GetSpriteFlippedVertically
+//****f* Sprite/Properties/GetSpriteFlippedV
 // FUNCTION
 //   Returns 1 if the sprite has been flipped vertically with SetSpriteFlip, otherwise returns 0.
 // INPUTS
 //   iSpriteIndex -- The ID of the sprite to check.
 // SOURCE
-int agk::GetSpriteFlippedVertically( UINT iSpriteIndex )
+int agk::GetSpriteFlippedV( UINT iSpriteIndex )
 //****
 {
 	cSprite *pSprite = (cSprite*)m_cSpriteList.GetItem( iSpriteIndex );

--- a/common/Source/Wrapper.cpp
+++ b/common/Source/Wrapper.cpp
@@ -8390,6 +8390,50 @@ int agk::GetSpriteTransparency( UINT iSpriteIndex )
 	return pSprite->GetTransparencyMode();
 }
 
+//****f* Sprite/Properties/GetSpriteFlippedHorizontally
+// FUNCTION
+//   Returns 1 if the sprite has been flipped horizontally with SetSpriteFlip, otherwise returns 0.
+// INPUTS
+//   iSpriteIndex -- The ID of the sprite to check.
+// SOURCE
+int agk::GetSpriteFlippedHorizontally( UINT iSpriteIndex )
+//****
+{
+	cSprite *pSprite = (cSprite*)m_cSpriteList.GetItem( iSpriteIndex );
+	if ( pSprite == UNDEF )
+	{
+#ifdef _AGK_ERROR_CHECK
+		uString errStr( "Sprite ", 50 );  errStr.AppendUInt( iSpriteIndex );  errStr.Append( " does not exist" );
+		Error( errStr );
+#endif
+		return 0;
+	}
+
+	return pSprite->GetFlippedHorizontally();
+}
+
+//****f* Sprite/Properties/GetSpriteFlippedVertically
+// FUNCTION
+//   Returns 1 if the sprite has been flipped vertically with SetSpriteFlip, otherwise returns 0.
+// INPUTS
+//   iSpriteIndex -- The ID of the sprite to check.
+// SOURCE
+int agk::GetSpriteFlippedVertically( UINT iSpriteIndex )
+//****
+{
+	cSprite *pSprite = (cSprite*)m_cSpriteList.GetItem( iSpriteIndex );
+	if ( pSprite == UNDEF )
+	{
+#ifdef _AGK_ERROR_CHECK
+		uString errStr( "Sprite ", 50 );  errStr.AppendUInt( iSpriteIndex );  errStr.Append( " does not exist" );
+		Error( errStr );
+#endif
+		return 0;
+	}
+
+	return pSprite->GetFlippedVertically();
+}
+
 //****f* Sprite/Properties/GetSpriteXFromPixel
 // FUNCTION
 //   Converts a pixel point on the sprite's image to the point on the sprite's surface that represents where that pixel is.

--- a/common/Source/cSprite.cpp
+++ b/common/Source/cSprite.cpp
@@ -2978,6 +2978,16 @@ int cSprite::HasAdditionalImages()
 	return 0;
 }
 
+bool cSprite::GetFlippedHorizontally()
+{
+	return 0 != (m_bFlags & AGK_SPRITE_FLIPH);
+}
+
+bool cSprite::GetFlippedVertically()
+{
+	return 0 != (m_bFlags & AGK_SPRITE_FLIPV);
+}
+
 void cSprite::SetUV( float u1, float v1, float u2, float v2, float u3, float v3, float u4, float v4 )
 {
 	m_bUVOverride = true;

--- a/common/include/Wrapper.h
+++ b/common/include/Wrapper.h
@@ -1184,8 +1184,8 @@ namespace AGK
 			static int GetSpriteActive( UINT iSpriteIndex );
 			static int GetSpriteGroup( UINT iSpriteIndex );
 			static int GetSpriteTransparency( UINT iSpriteIndex );
-			static int GetSpriteFlippedHorizontally(UINT iSpriteIndex);
-			static int GetSpriteFlippedVertically(UINT iSpriteIndex);
+			static int GetSpriteFlippedH(UINT iSpriteIndex);
+			static int GetSpriteFlippedV(UINT iSpriteIndex);
 
 			static float GetSpriteXFromPixel( UINT iSpriteIndex, int x );
 			static float GetSpriteYFromPixel( UINT iSpriteIndex, int y );

--- a/common/include/Wrapper.h
+++ b/common/include/Wrapper.h
@@ -1184,6 +1184,8 @@ namespace AGK
 			static int GetSpriteActive( UINT iSpriteIndex );
 			static int GetSpriteGroup( UINT iSpriteIndex );
 			static int GetSpriteTransparency( UINT iSpriteIndex );
+			static int GetSpriteFlippedHorizontally(UINT iSpriteIndex);
+			static int GetSpriteFlippedVertically(UINT iSpriteIndex);
 
 			static float GetSpriteXFromPixel( UINT iSpriteIndex, int x );
 			static float GetSpriteYFromPixel( UINT iSpriteIndex, int y );

--- a/common/include/cSprite.h
+++ b/common/include/cSprite.h
@@ -261,6 +261,8 @@ namespace AGK
 			int GetGroup				( void );
 			int HasAdditionalImages		( void );
 			bool IsManaged() { return m_bManaged; }
+			bool GetFlippedHorizontally	( void );
+			bool GetFlippedVertically	( void );
 
 			AGKShader* GetShader() { return m_pShader; }
 			void SetShader( AGKShader* shader ); 


### PR DESCRIPTION
These are a couple of getter functions I've found useful in my own Tier 2 projects to avoid having to store additional state about whether I've flipped any given sprite or not.