### PR TITLE
Fixed comparison leading to erroneous warnings about scale values in bones

### DIFF
--- a/common/Source/cObject3D.cpp
+++ b/common/Source/cObject3D.cpp
@@ -1119,7 +1119,7 @@ void cObject3D::LoadObject( const char *szFilename, int withChildren,  float hei
 
 				pos *= meshscale;
 
-				if ( warned == 0 && (agk::Abs(scale.x-1) > 0.01f || agk::Abs(scale.y-1) > 0.01f || agk::Abs(scale.z-1) > 0.01f) )
+				if ( warned == 0 && (agk::Abs(scale.x)-1 > 0.01f || agk::Abs(scale.y)-1 > 0.01f || agk::Abs(scale.z)-1 > 0.01f) )
 				{
 					warned = 1;
 					agk::Warning( "Bone transform matrix contains scale values, scaling of bones is not supported and will be ignored" );
@@ -1171,7 +1171,7 @@ void cObject3D::LoadObject( const char *szFilename, int withChildren,  float hei
 						pBone->m_offsetPosition.Set( pos.x, pos.y, pos.z );
 						pBone->m_offsetRotation.Set( rot.w, rot.x, rot.y, rot.z );
 
-						if ( warned2 == 0 && (agk::Abs(scale.x-1) > 0.01f || agk::Abs(scale.y-1) > 0.01f || agk::Abs(scale.z-1) > 0.01f) )
+						if ( warned2 == 0 && (agk::Abs(scale.x)-1 > 0.01f || agk::Abs(scale.y)-1 > 0.01f || agk::Abs(scale.z)-1 > 0.01f) )
 						{
 							warned2 = 1;
 							agk::Warning( "Bone offset matrix contains scale values, it may not display correctly" );


### PR DESCRIPTION
The subject is self explanatory. AGK was issuing a warning about scale values being present in bones, when in fact there wasn't any scaling, because the comparison was fabs(scale-1) > 0.01f instead of fabs(scale)-1 > 0.01f. A scale value of 1 is, of course, no scaling.