### PR TITLE
Remove collisions from debug objects for the 3d physics character 

### DIFF
--- a/common/Source/CharacterController.cpp
+++ b/common/Source/CharacterController.cpp
@@ -58,8 +58,10 @@ void CharacterController::Create( int objectID, int axis, const btVector3& objec
 
 	int debugObjectID = agk::CreateObjectCapsule( diameter, height, axis );
 	agk::SetObjectVisible( debugObjectID, false );
+	agk::SetObjectCollisionMode( debugObjectID, false );
 	int debugObjectID_Crouch = agk::CreateObjectCapsule( diameter, height * crouchScale, axis );
 	agk::SetObjectVisible(debugObjectID_Crouch, false );
+	agk::SetObjectCollisionMode( debugObjectID_Crouch, false );
 
 	agk::SetObjectPosition( debugObjectID, agk::GetObjectX( objectID ), agk::GetObjectY( objectID ), agk::GetObjectZ( objectID ) );
 	agk::SetObjectPosition(debugObjectID_Crouch, agk::GetObjectX(objectID), agk::GetObjectY(objectID), agk::GetObjectZ(objectID));


### PR DESCRIPTION
Currently creating a 3d physics character controller creates two debug objects that are immediately set invisible. These can be shown with Debug3DPhysicsCharacterController( objID, isDebug ). The problem is that collisions are still active for these objects. This means that if you call a raycast to your player object, often times depending on your player shape it will collide with these 2 "phantom" objects that you do not have access to. By turning off the collisions immediately we can fix this issue. This needs to be applied to both tier 1 and 2. Included the example project as well.

Example:
![image](https://github.com/TheGameCreators/AGKTier2/assets/40530732/45b926e3-bccc-4a23-a5d5-9c1e6df66f8d)


Example with debug capsule visible:
![image](https://github.com/TheGameCreators/AGKTier2/assets/40530732/a8e10ae9-61b4-421c-bdee-1f2548c11d11)

[test.zip](https://github.com/TheGameCreators/AGKTier2/files/13854986/test.zip)